### PR TITLE
feat: add unauthenticated redirect

### DIFF
--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -31,7 +31,15 @@ export async function updateSession(request: NextRequest) {
 
   // createServerClientとsupabase.auth.getClaims()の間にコードを書いてはいけない。
   // クライアントサイドとサーバーサイドで認証セッションが同期されず、意図しないログアウトが発生する恐れがある。
-  await supabase.auth.getClaims();
+  const { data } = await supabase.auth.getClaims();
+  const claims = data?.claims;
+
+  if (!claims) {
+    // 未認証なら、ログイン画面にリダイレクト
+    const url = request.nextUrl.clone();
+    url.pathname = '/login';
+    return NextResponse.redirect(url);
+  }
 
   return supabaseResponse;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,9 +1,9 @@
-import { type NextRequest } from 'next/server'
-import { updateSession } from '@/lib/supabase/proxy'
+import { type NextRequest } from 'next/server';
+import { updateSession } from '@/lib/supabase/proxy';
 
-export async function proxy(request: NextRequest) {
+export default async function proxy(request: NextRequest) {
   // ユーザの認証セッションを更新する。
-  return await updateSession(request)
+  return await updateSession(request);
 }
 
 export const config = {
@@ -14,9 +14,10 @@ export const config = {
      * - _next/image （画像最適化ファイル）
      * - favicon.ico（ファビコン）
      * - svg・png・jpg・jpeg・gif・webp（画像ファイル）
+     * - トップページ、新規登録ページ、ログインページ
      * これらのパスは、認証セッションの更新が不要なため除外する。
      * 必要に応じて、不要なパターンを追記する。
      */
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)|$|signup|login$).*)',
   ],
-}
+};


### PR DESCRIPTION
## 概要
未認証状態で保護されたページにアクセスできないようにしました。

## 変更内容
- proxy.tsをsrc/配下に移動
- 未認証時のリダイレクト処理の実装
- トップページ、新規登録ページ、ログインページの認証チェック除外の設定

## 備考
proxy.tsをルート直下に置いていたが、srcディレクトリ構成の場合はsrc/配下に置く必要があることに気づきました。この配置ミスにより、未認証リダイレクトが機能していなかったため、修正しました。

## 関連Issue
Close #17 