### PR TITLE
feat: add task create from inbox

### DIFF
--- a/src/app/(main)/dashboard/_components/Inbox.tsx
+++ b/src/app/(main)/dashboard/_components/Inbox.tsx
@@ -1,4 +1,8 @@
+'use client';
+
 import { Task } from '@/types/task';
+import Modal from './Modal';
+import TaskCreateForm from './TaskCreateForm';
 
 type InboxProps = {
   tasks: Task[];
@@ -7,6 +11,18 @@ type InboxProps = {
 function Inbox({ tasks }: InboxProps) {
   return (
     <div className="flex flex-col h-full">
+      <div className="flex justify-start p-2">
+        <Modal
+          trigger={
+            <button className="px-4 py-2 bg-black text-white rounded hover:bg-zinc-700">
+              登録
+            </button>
+          }
+          title={'タスク登録'}
+        >
+          {(onSuccess) => <TaskCreateForm onSuccess={onSuccess} />}
+        </Modal>
+      </div>
       <div className="flex-1 overflow-y-auto">
         {tasks.map((task) => (
           <div

--- a/src/app/(main)/dashboard/_components/Modal.tsx
+++ b/src/app/(main)/dashboard/_components/Modal.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+
+type ModalProps = {
+  trigger: React.ReactNode;
+  title: string;
+  children: (onSuccess: () => void) => React.ReactNode;
+};
+
+function Modal({ trigger, title, children }: ModalProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent>
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription className="sr-only">{title}</DialogDescription>
+        {children(() => setOpen(false))}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default Modal;

--- a/src/app/(main)/dashboard/_components/TaskCreateForm.tsx
+++ b/src/app/(main)/dashboard/_components/TaskCreateForm.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useActionState, useEffect } from 'react';
+import { createTask, TaskState } from '../actions';
+
+type TaskCreateFormProps = {
+  onSuccess: () => void;
+};
+
+function TaskCreateForm({ onSuccess }: TaskCreateFormProps) {
+  const [state, action] = useActionState<TaskState, FormData>(createTask, {
+    error: '',
+    success: false,
+  });
+
+  useEffect(() => {
+    if (state.success) {
+      onSuccess();
+    }
+  }, [state.success, onSuccess]);
+
+  return (
+    <div className="flex items-center justify-center">
+      <div className="bg-white shadow-md rounded-lg p-8 w-80">
+        <form action={action}>
+          <div>
+            <label className="block mb-1">タイトル</label>
+            <input
+              type="text"
+              name="title"
+              className="border rounded w-full p-2 mb-4 outline-none focus:ring-2 focus:ring-black"
+            />
+          </div>
+          <div>
+            <label className="block mb-1">見込み時間</label>
+            <input
+              type="number"
+              name="estimated_minutes"
+              className="border rounded w-full p-2 mb-4 outline-none focus:ring-2 focus:ring-black"
+            />
+          </div>
+          <div>
+            <label className="block mb-1">メモ</label>
+            <input
+              type="text"
+              name="memo"
+              className="border rounded w-full p-2 mb-4 outline-none focus:ring-2 focus:ring-black"
+            />
+          </div>
+          <div>
+            <button className="px-4 py-2 bg-black text-white rounded hover:bg-zinc-700">
+              登録
+            </button>
+            {state.error && <p>エラー: {state.error}</p>}
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default TaskCreateForm;

--- a/src/app/(main)/dashboard/actions.ts
+++ b/src/app/(main)/dashboard/actions.ts
@@ -1,0 +1,62 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { revalidatePath } from 'next/cache';
+import { insertTask } from '@/repositories/tasks';
+
+export type TaskState = {
+  error: string;
+  success: boolean;
+};
+
+export async function createTask(prevState: TaskState, formData: FormData) {
+  const title = formData.get('title');
+  const estimatedMinutesStr = formData.get('estimated_minutes');
+  const memo = formData.get('memo');
+
+  if (
+    typeof title !== 'string' ||
+    typeof estimatedMinutesStr !== 'string' ||
+    typeof memo !== 'string'
+  ) {
+    return { error: '入力内容を確認してください。', success: false };
+  }
+
+  if (!title || !estimatedMinutesStr) {
+    return { error: '空欄の項目があります。', success: false };
+  }
+
+  const estimatedMinutes = Number(estimatedMinutesStr);
+
+  if (isNaN(estimatedMinutes) || estimatedMinutes <= 0) {
+    return {
+      error: '見込み時間は1以上の数値を入力してください。',
+      success: false,
+    };
+  }
+
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: '認証エラーが発生しました。', success: false };
+  }
+
+  const { error: tasksError } = await insertTask(
+    supabase,
+    user.id,
+    title,
+    estimatedMinutes,
+    memo,
+  );
+
+  if (tasksError) {
+    return { error: tasksError.message, success: false };
+  } else {
+    revalidatePath('/dashboard');
+    return { error: '', success: true };
+  }
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Slot } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground [a]:hover:bg-primary/80',
+        outline:
+          'border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
+        ghost:
+          'hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50',
+        destructive:
+          'bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default:
+          'h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: 'h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+        icon: 'size-8',
+        'icon-xs':
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        'icon-sm':
+          'size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg',
+        'icon-lg': 'size-9',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+function Button({
+  className,
+  variant = 'default',
+  size = 'default',
+  asChild = false,
+  ...props
+}: React.ComponentProps<'button'> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot.Root : 'button';
+
+  return (
+    <Comp
+      data-slot="button"
+      data-variant={variant}
+      data-size={size}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import * as React from 'react';
+import { Dialog as DialogPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { XIcon } from 'lucide-react';
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close data-slot="dialog-close" asChild>
+            <Button
+              variant="ghost"
+              className="absolute top-2 right-2"
+              size="icon-sm"
+            >
+              <XIcon />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-2', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<'div'> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        '-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        'font-heading text-base leading-none font-medium',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        'text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/src/repositories/tasks.ts
+++ b/src/repositories/tasks.ts
@@ -11,3 +11,20 @@ export async function getInboxTasks(supabase: SupabaseClient) {
 
   return { data, error };
 }
+
+export async function insertTask(
+  supabase: SupabaseClient,
+  userId: string,
+  title: string,
+  estimatedMinutes: number,
+  memo: string,
+) {
+  const { error } = await supabase.from('tasks').insert({
+    user_id: userId,
+    title,
+    estimated_minutes: estimatedMinutes,
+    memo,
+  });
+
+  return { error };
+}


### PR DESCRIPTION
## 概要
タスクを登録できるようにしました。

## 変更内容
- shadcn/uiのdialog, buttonを導入
- モーダルUIを実装
- タスク登録フォームを実装
- タスク登録処理を実装

## 備考
- Render Propsパターンを使ってModalの開閉状態をModal内部で管理する形にしました。
- タスク登録後はrevalidatePathでインボックスを再取得しています。

## 関連Issue
Close #19 