### PR TITLE
fix: set inbox height to half screen

### DIFF
--- a/src/app/(main)/dashboard/_components/InboxDrawer.tsx
+++ b/src/app/(main)/dashboard/_components/InboxDrawer.tsx
@@ -21,7 +21,7 @@ function InboxDrawer({
           INBOX
         </div>
       </DrawerTrigger>
-      <DrawerContent className="min-h-[50vh]">
+      <DrawerContent className="h-[50vh]">
         <DrawerHeader>
           <DrawerTitle>INBOX</DrawerTitle>
           <DrawerDescription className="sr-only">


### PR DESCRIPTION
## 概要
インボックスを画面の半分より上に広がらないようにしました。

## 変更内容
- ハーフモーダルを画面の半分で固定（min-h-[50vh] → h-[50vh]）

## 関連Issue
Close #40 