### PR TITLE
feat: add daily timeline view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/supabase-js": "^2.100.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "lucide-react": "^1.7.0",
         "next": "16.2.1",
         "radix-ui": "^1.4.3",
@@ -6263,6 +6264,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@supabase/supabase-js": "^2.100.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "lucide-react": "^1.7.0",
     "next": "16.2.1",
     "radix-ui": "^1.4.3",

--- a/src/app/(main)/dashboard/_components/DateNavigation.tsx
+++ b/src/app/(main)/dashboard/_components/DateNavigation.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { addDays, subDays } from 'date-fns';
+import { useRouter } from 'next/navigation';
+
+type DateNavigationProps = {
+  date: string,
+};
+
+function DateNavigation({ date }: DateNavigationProps) {
+
+  const router = useRouter();
+
+  const handlePrevDay = () => {
+    const prevDay = subDays(new Date(date), 1).toISOString().split('T')[0];
+    router.push(`/dashboard?date=${prevDay}`);
+  }
+
+  const handleNextDay = () => {
+    const nextDay = addDays(new Date(date), 1).toISOString().split('T')[0];
+    router.push(`/dashboard?date=${nextDay}`);
+  }
+
+  return (
+    <div className="flex items-center justify-between px-4 py-2">
+      <button onClick={handlePrevDay}><ChevronLeft /></button>
+      <span>{date}</span>
+      <button onClick={handleNextDay}><ChevronRight /></button>
+    </div>
+  );
+}
+
+export default DateNavigation;

--- a/src/app/(main)/dashboard/_components/Timeline.tsx
+++ b/src/app/(main)/dashboard/_components/Timeline.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { Task } from '@/types/task';
+import { Schedule } from '@/types/schedule';
+import DateNavigation from './DateNavigation';
+
+type TimelineProps = {
+  schedules: Schedule[],
+  tasks: Task[],
+  date: string,
+};
+
+function Timeline({ schedules, tasks, date }: TimelineProps) {
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto">
+        <DateNavigation date={date}/>
+        {schedules.map((schedule) => (
+          <div
+            key={schedule.id}
+            className="border rounded-lg p-4 mb-2 bg-white shadow-sm"
+          >
+            <span>{schedule.title}</span>
+          </div>
+        ))}
+        {tasks.map((task) => (
+          <div
+            key={task.id}
+            className="border rounded-lg p-4 mb-2 bg-white shadow-sm"
+          >
+            <span>{task.title}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default Timeline;

--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -1,27 +1,54 @@
 import { createClient } from '@/lib/supabase/server';
-import { getInboxTasks } from '@/repositories/tasks';
+import { getInboxTasks, getDailyTasks } from '@/repositories/tasks';
+import { getDailySchedules } from '@/repositories/schedules';
 
 import Inbox from './_components/Inbox';
 import DashboardTabs from './_components/DashboardTabs';
+import Timeline from './_components/Timeline';
 
-async function Dashboard() {
+type DashboardProps = {
+  searchParams: Promise<{ date?: string }>;
+};
+
+async function Dashboard({ searchParams }: DashboardProps) {
   const supabase = await createClient();
 
-  const { data: tasks, error: tasksError } = await getInboxTasks(supabase);
+  const { date } = await searchParams;
+
+  // dateパラメータが未指定の場合は今日日付をデフォルトにする。
+  const targetDate = date ?? new Date().toISOString().split('T')[0];
+
+  const { data: inboxTasks, error: inboxTasksError } =
+    await getInboxTasks(supabase);
+  const { data: scheduledTasks, error: scheduledTasksError } =
+    await getDailyTasks(supabase, targetDate);
+  const { data: schedules, error: schedulesError } = await getDailySchedules(
+    supabase,
+    targetDate,
+  );
 
   return (
     <DashboardTabs
       tabs={[
         {
           label: 'タイムライン',
-          content: <div>タイムライン（未実装）</div>,
+          content:
+            scheduledTasksError || schedulesError ? (
+              <div>スケジュールの取得に失敗しました。再度お試しください。</div>
+            ) : (
+              <Timeline
+                schedules={schedules ?? []}
+                tasks={scheduledTasks ?? []}
+                date={targetDate}
+              />
+            ),
         },
         {
           label: 'インボックス',
-          content: tasksError ? (
+          content: inboxTasksError ? (
             <div>タスクの取得に失敗しました。再度お試しください。</div>
           ) : (
-            <Inbox tasks={tasks ?? []} />
+            <Inbox tasks={inboxTasks ?? []} />
           ),
         },
       ]}

--- a/src/repositories/schedules.ts
+++ b/src/repositories/schedules.ts
@@ -1,0 +1,24 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { addDays } from 'date-fns';
+
+import { Schedule } from '@/types/schedule';
+
+export async function getDailySchedules(
+  supabase: SupabaseClient,
+  date: string,
+) {
+  const startOfDay = new Date(`${date}T00:00:00+09:00`);
+
+  const endOfDay = addDays(startOfDay, 1);
+
+  // start_timeで絞り込む。日を跨ぐスケジュールは開始日の予定として扱うため。
+  const { data, error } = await supabase
+    .from('schedules')
+    .select('*')
+    .is('deleted_at', null)
+    .gte('start_time', startOfDay.toISOString())
+    .lt('start_time', endOfDay.toISOString())
+    .returns<Schedule[]>();
+
+  return { data, error };
+}

--- a/src/repositories/tasks.ts
+++ b/src/repositories/tasks.ts
@@ -1,4 +1,5 @@
 import { SupabaseClient } from '@supabase/supabase-js';
+import { addDays } from 'date-fns';
 
 import { Task } from '@/types/task';
 
@@ -8,6 +9,24 @@ export async function getInboxTasks(supabase: SupabaseClient) {
     .select('*')
     .eq('status', 'INBOX')
     .is('deleted_at', null)
+    .returns<Task[]>();
+
+  return { data, error };
+}
+
+export async function getDailyTasks(supabase: SupabaseClient, date: string) {
+  const startOfDay = new Date(`${date}T00:00:00+09:00`);
+
+  const endOfDay = addDays(startOfDay, 1);
+
+  // start_timeで絞り込む。日を跨ぐタスクは開始日の予定として扱うため。
+  const { data, error } = await supabase
+    .from('tasks')
+    .select('*')
+    .eq('status', 'SCHEDULED')
+    .is('deleted_at', null)
+    .gte('start_time', startOfDay.toISOString())
+    .lt('start_time', endOfDay.toISOString())
     .returns<Task[]>();
 
   return { data, error };

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,0 +1,11 @@
+export type Schedule = {
+  id: string;
+  user_id: string;
+  title: string;
+  memo: string | null;
+  start_time: string;
+  end_time: string;
+  created_at: string;
+  updated_at: string | null;
+  deleted_at: string | null;
+};


### PR DESCRIPTION
## 概要
日次ビューを実装しました。

## 変更内容
- タスク(指定日)取得処理を実装
- スケジュール(指定日)取得処理を実装
- 取得済みタスクやスケジュールを表示
- 日付ナビゲーションを実装

## 関連Issue
Close #21 