### PR TITLE
feat: add timeline logic and improve daily view

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,10 @@ const eslintConfig = defineConfig([
           "newlines-between": "always",
         },
       ],
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }
+      ],
     },
   },
   // Override default ignores of eslint-config-next.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "lucide-react": "^1.7.0",
         "next": "16.2.1",
         "radix-ui": "^1.4.3",
@@ -6274,6 +6275,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "lucide-react": "^1.7.0",
     "next": "16.2.1",
     "radix-ui": "^1.4.3",

--- a/src/app/(main)/dashboard/_components/DateNavigation.tsx
+++ b/src/app/(main)/dashboard/_components/DateNavigation.tsx
@@ -5,28 +5,31 @@ import { addDays, subDays } from 'date-fns';
 import { useRouter } from 'next/navigation';
 
 type DateNavigationProps = {
-  date: string,
+  date: string;
 };
 
 function DateNavigation({ date }: DateNavigationProps) {
-
   const router = useRouter();
 
   const handlePrevDay = () => {
     const prevDay = subDays(new Date(date), 1).toISOString().split('T')[0];
     router.push(`/dashboard?date=${prevDay}`);
-  }
+  };
 
   const handleNextDay = () => {
     const nextDay = addDays(new Date(date), 1).toISOString().split('T')[0];
     router.push(`/dashboard?date=${nextDay}`);
-  }
+  };
 
   return (
     <div className="flex items-center justify-between px-4 py-2">
-      <button onClick={handlePrevDay}><ChevronLeft /></button>
+      <button onClick={handlePrevDay}>
+        <ChevronLeft />
+      </button>
       <span>{date}</span>
-      <button onClick={handleNextDay}><ChevronRight /></button>
+      <button onClick={handleNextDay}>
+        <ChevronRight />
+      </button>
     </div>
   );
 }

--- a/src/app/(main)/dashboard/_components/Timeline.tsx
+++ b/src/app/(main)/dashboard/_components/Timeline.tsx
@@ -1,39 +1,45 @@
 'use client';
 
-import { Task } from '@/types/task';
-import { Schedule } from '@/types/schedule';
+import { format } from 'date-fns';
+import { toZonedTime } from 'date-fns-tz';
+
+import { TimelineItem } from '@/types/timeline';
+
 import DateNavigation from './DateNavigation';
 
 type TimelineProps = {
-  schedules: Schedule[],
-  tasks: Task[],
-  date: string,
+  date: string;
+  timeline: TimelineItem[];
 };
 
-function Timeline({ schedules, tasks, date }: TimelineProps) {
+function Timeline({ date, timeline }: TimelineProps) {
   return (
     <div className="flex flex-col h-full">
       <div className="flex-1 overflow-y-auto">
-        <DateNavigation date={date}/>
-        {schedules.map((schedule) => (
+        <DateNavigation date={date} />
+        {timeline.map((item) => (
           <div
-            key={schedule.id}
+            key={item.id}
             className="border rounded-lg p-4 mb-2 bg-white shadow-sm"
           >
-            <span>{schedule.title}</span>
-          </div>
-        ))}
-        {tasks.map((task) => (
-          <div
-            key={task.id}
-            className="border rounded-lg p-4 mb-2 bg-white shadow-sm"
-          >
-            <span>{task.title}</span>
+            <div className="flex items-center gap-4">
+              <span className="w-24 shrink-0 text-sm text-gray-500">
+                {item.type === 'gap' && item.isFullDay
+                  ? '終日'
+                  : `${formatTime(item.start_time)}〜${formatTime(item.end_time)}`}
+              </span>
+              <span>{item.type === 'gap' ? '空き時間' : item.title}</span>
+            </div>
           </div>
         ))}
       </div>
     </div>
   );
 }
+
+const formatTime = (isoString: string) => {
+  const zonedDate = toZonedTime(isoString, 'Asia/Tokyo');
+  return format(zonedDate, 'HH:mm');
+};
 
 export default Timeline;

--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { getInboxTasks, getDailyTasks } from '@/repositories/tasks';
 import { getDailySchedules } from '@/repositories/schedules';
+import { buildDailyTimeline } from '@/utils/timeline';
 
 import Inbox from './_components/Inbox';
 import DashboardTabs from './_components/DashboardTabs';
@@ -27,6 +28,12 @@ async function Dashboard({ searchParams }: DashboardProps) {
     targetDate,
   );
 
+  const timeline = buildDailyTimeline(
+    targetDate,
+    schedules ?? [],
+    scheduledTasks ?? [],
+  );
+
   return (
     <DashboardTabs
       tabs={[
@@ -36,11 +43,7 @@ async function Dashboard({ searchParams }: DashboardProps) {
             scheduledTasksError || schedulesError ? (
               <div>スケジュールの取得に失敗しました。再度お試しください。</div>
             ) : (
-              <Timeline
-                schedules={schedules ?? []}
-                tasks={scheduledTasks ?? []}
-                date={targetDate}
-              />
+              <Timeline date={targetDate} timeline={timeline} />
             ),
         },
         {

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -1,0 +1,30 @@
+import { Schedule } from '@/types/schedule';
+import { Task } from '@/types/task';
+
+export type TimelineItem = ScheduleItem | TaskItem | GapItem;
+
+type ScheduleItem = {
+  type: 'schedule';
+  id: string;
+  title: string;
+  start_time: string;
+  end_time: string;
+  schedule: Schedule;
+};
+
+type TaskItem = {
+  type: 'task';
+  id: string;
+  title: string;
+  start_time: string;
+  end_time: string;
+  task: Task;
+};
+
+type GapItem = {
+  type: 'gap';
+  id: string;
+  start_time: string;
+  end_time: string;
+  isFullDay: boolean;
+};

--- a/src/utils/timeline.test.ts
+++ b/src/utils/timeline.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { Task } from '@/types/task';
+import { Schedule } from '@/types/schedule';
+
+import { buildDailyTimeline } from './timeline';
+
+let idCounter = 0;
+
+describe('buildDailyTimeline', () => {
+  beforeEach(() => {
+    idCounter = 0;
+  });
+
+  it('マージ処理: スケジュールとタスクが両方ある場合、両方がマージされること', () => {
+    const date = '2026-04-26';
+    const schedules = [
+      createSchedule('2026-04-26T10:00:00+09:00', '2026-04-26T11:00:00+09:00'),
+      createSchedule('2026-04-26T15:00:00+09:00', '2026-04-26T16:00:00+09:00'),
+    ];
+    const tasks = [
+      createTask('2026-04-26T12:00:00+09:00', '2026-04-26T13:00:00+09:00'),
+      createTask('2026-04-26T17:00:00+09:00', '2026-04-26T18:00:00+09:00'),
+    ];
+
+    const result = buildDailyTimeline(date, schedules, tasks);
+
+    expect(result.filter((item) => item.type === 'schedule')).toHaveLength(2);
+    expect(result.filter((item) => item.type === 'task')).toHaveLength(2);
+  });
+
+  it('マージ処理: スケジュールだけの場合、スケジュールのみがマージされること', () => {
+    const date = '2026-04-26';
+    const schedules = [
+      createSchedule('2026-04-26T10:00:00+09:00', '2026-04-26T11:00:00+09:00'),
+      createSchedule('2026-04-26T15:00:00+09:00', '2026-04-26T16:00:00+09:00'),
+    ];
+    const tasks: Task[] = [];
+
+    const result = buildDailyTimeline(date, schedules, tasks);
+
+    expect(result.filter((item) => item.type === 'schedule')).toHaveLength(2);
+    expect(result.filter((item) => item.type === 'task')).toHaveLength(0);
+  });
+
+  it('マージ処理: タスクだけの場合、タスクのみがマージされること', () => {
+    const date = '2026-04-26';
+    const schedules: Schedule[] = [];
+    const tasks = [
+      createTask('2026-04-26T12:00:00+09:00', '2026-04-26T13:00:00+09:00'),
+      createTask('2026-04-26T17:00:00+09:00', '2026-04-26T18:00:00+09:00'),
+    ];
+
+    const result = buildDailyTimeline(date, schedules, tasks);
+
+    expect(result.filter((item) => item.type === 'schedule')).toHaveLength(0);
+    expect(result.filter((item) => item.type === 'task')).toHaveLength(2);
+  });
+
+  it('ソート処理: ランダムな時間順の場合、start_timeの昇順になること', () => {
+    const date = '2026-04-26';
+    const schedules = [
+      createSchedule('2026-04-26T15:00:00+09:00', '2026-04-26T18:00:00+09:00'),
+      createSchedule('2026-04-26T10:00:00+09:00', '2026-04-26T12:00:00+09:00'),
+    ];
+    const tasks = [
+      createTask('2026-04-26T20:00:00+09:00', '2026-04-26T21:00:00+09:00'),
+      createTask('2026-04-26T13:00:00+09:00', '2026-04-26T14:00:00+09:00'),
+    ];
+
+    const result = buildDailyTimeline(date, schedules, tasks);
+
+    const nonGapItems = result.filter((item) => item.type !== 'gap');
+    const startTimes = nonGapItems.map((item) => item.start_time);
+    expect(startTimes).toEqual([
+      `2026-04-26T10:00:00+09:00`,
+      `2026-04-26T13:00:00+09:00`,
+      `2026-04-26T15:00:00+09:00`,
+      `2026-04-26T20:00:00+09:00`,
+    ]);
+  });
+
+  it('ソート処理: start_timeが同一の場合、end_timeの昇順になること', () => {
+    const date = '2026-04-26';
+    const schedules = [
+      createSchedule('2026-04-26T10:00:00+09:00', '2026-04-26T12:00:00+09:00'),
+      createSchedule('2026-04-26T10:00:00+09:00', '2026-04-26T11:00:00+09:00'),
+    ];
+    const tasks = [
+      createTask('2026-04-26T10:00:00+09:00', '2026-04-26T20:00:00+09:00'),
+      createTask('2026-04-26T10:00:00+09:00', '2026-04-26T15:00:00+09:00'),
+    ];
+
+    const result = buildDailyTimeline(date, schedules, tasks);
+
+    const nonGapItems = result.filter((item) => item.type !== 'gap');
+    const endTimes = nonGapItems.map((item) => item.end_time);
+    expect(endTimes).toEqual([
+      `2026-04-26T11:00:00+09:00`,
+      `2026-04-26T12:00:00+09:00`,
+      `2026-04-26T15:00:00+09:00`,
+      `2026-04-26T20:00:00+09:00`,
+    ]);
+  });
+
+  it('ソート処理: start_timeとend_timeが同一の場合、typeの昇順になること', () => {
+    const date = '2026-04-26';
+    const schedules = [
+      createSchedule('2026-04-26T10:00:00+09:00', '2026-04-26T11:00:00+09:00'),
+    ];
+    const tasks = [
+      createTask('2026-04-26T10:00:00+09:00', '2026-04-26T11:00:00+09:00'),
+    ];
+
+    const result = buildDailyTimeline(date, schedules, tasks);
+
+    const nonGapItems = result.filter((item) => item.type !== 'gap');
+    const types = nonGapItems.map((item) => item.type);
+    expect(types).toEqual(['schedule', 'task']);
+  });
+
+  it('ソート処理: start_timeとend_time、typeが同一の場合、idの昇順になること', () => {
+    const date = '2026-04-26';
+    const schedules = [
+      createSchedule(
+        '2026-04-26T10:00:00+09:00',
+        '2026-04-26T11:00:00+09:00',
+        '3',
+      ),
+      createSchedule(
+        '2026-04-26T10:00:00+09:00',
+        '2026-04-26T11:00:00+09:00',
+        '2',
+      ),
+      createSchedule(
+        '2026-04-26T10:00:00+09:00',
+        '2026-04-26T11:00:00+09:00',
+        '1',
+      ),
+    ];
+    const tasks: Task[] = [];
+
+    const result = buildDailyTimeline(date, schedules, tasks);
+
+    const nonGapItems = result.filter((item) => item.type !== 'gap');
+    const ids = nonGapItems.map((item) =>
+      item.type === 'schedule' ? item.schedule.id : item.task.id,
+    );
+    expect(ids).toEqual(['1', '2', '3']);
+  });
+
+  it('空き時間処理: 開始・アイテム間・終了に空き時間ができること', () => {
+    const date = '2026-04-26';
+    const schedules = [
+      createSchedule('2026-04-26T10:00:00+09:00', '2026-04-26T11:00:00+09:00'),
+      createSchedule('2026-04-26T11:30:00+09:00', '2026-04-26T13:00:00+09:00'),
+      createSchedule('2026-04-26T16:30:00+09:00', '2026-04-26T20:00:00+09:00'),
+    ];
+    const tasks = [
+      createTask('2026-04-26T13:30:00+09:00', '2026-04-26T14:00:00+09:00'),
+      createTask('2026-04-26T15:00:00+09:00', '2026-04-26T16:00:00+09:00'),
+    ];
+    const result = buildDailyTimeline(date, schedules, tasks);
+
+    // idを除外
+    // Gapのidはcrypto.randomUUID()で生成していて、毎回異なる値になるため。
+    const gapItems = result
+      .filter((item) => item.type === 'gap')
+      .map(({ id: _id, ...rest }) => rest);
+    expect(gapItems).toEqual([
+      {
+        type: 'gap',
+        start_time: `2026-04-26T00:00:00+09:00`,
+        end_time: `2026-04-26T10:00:00+09:00`,
+        isFullDay: false,
+      },
+      {
+        type: 'gap',
+        start_time: `2026-04-26T11:00:00+09:00`,
+        end_time: `2026-04-26T11:30:00+09:00`,
+        isFullDay: false,
+      },
+      {
+        type: 'gap',
+        start_time: `2026-04-26T13:00:00+09:00`,
+        end_time: `2026-04-26T13:30:00+09:00`,
+        isFullDay: false,
+      },
+      {
+        type: 'gap',
+        start_time: `2026-04-26T14:00:00+09:00`,
+        end_time: `2026-04-26T15:00:00+09:00`,
+        isFullDay: false,
+      },
+      {
+        type: 'gap',
+        start_time: `2026-04-26T16:00:00+09:00`,
+        end_time: `2026-04-26T16:30:00+09:00`,
+        isFullDay: false,
+      },
+      {
+        type: 'gap',
+        start_time: `2026-04-26T20:00:00+09:00`,
+        end_time: '2026-04-27T00:00:00+09:00',
+        isFullDay: false,
+      },
+    ]);
+  });
+
+  it('空き時間処理: アイテムが隣接している場合、空き時間ができないこと', () => {
+    const date = '2026-04-26';
+    const schedules = [
+      createSchedule('2026-04-26T00:00:00+09:00', '2026-04-26T10:00:00+09:00'),
+      createSchedule('2026-04-26T10:00:00+09:00', '2026-04-26T11:00:00+09:00'),
+      createSchedule('2026-04-26T11:00:00+09:00', '2026-04-26T12:00:00+09:00'),
+    ];
+    const tasks = [
+      createTask('2026-04-26T12:00:00+09:00', '2026-04-26T14:00:00+09:00'),
+      createTask('2026-04-26T14:00:00+09:00', '2026-04-26T16:00:00+09:00'),
+      createTask('2026-04-26T16:00:00+09:00', '2026-04-27T00:00:00+09:00'),
+    ];
+    const result = buildDailyTimeline(date, schedules, tasks);
+
+    const gapItems = result.filter((item) => item.type === 'gap');
+    // 前後のGapのみ
+    expect(gapItems).toHaveLength(0);
+  });
+
+  it('空き時間処理: アイテムが重複している場合、空き時間ができないこと', () => {
+    const date = '2026-04-26';
+    const schedules = [
+      createSchedule('2026-04-26T00:00:00+09:00', '2026-04-26T10:00:00+09:00'),
+      createSchedule('2026-04-26T10:00:00+09:00', '2026-04-26T11:00:00+09:00'),
+      createSchedule('2026-04-26T10:30:00+09:00', '2026-04-26T12:00:00+09:00'),
+    ];
+    const tasks = [
+      createTask('2026-04-26T11:30:00+09:00', '2026-04-26T14:00:00+09:00'),
+      createTask('2026-04-26T13:00:00+09:00', '2026-04-26T16:00:00+09:00'),
+      createTask('2026-04-26T16:00:00+09:00', '2026-04-27T00:00:00+09:00'),
+    ];
+    const result = buildDailyTimeline(date, schedules, tasks);
+
+    const gapItems = result.filter((item) => item.type === 'gap');
+    // 前後のGapのみ
+    expect(gapItems).toHaveLength(0);
+  });
+
+  it('空き時間処理: 日を跨ぐタスクやスケジュールがある場合、終了の空き時間ができないこと', () => {
+    const date = '2026-04-26';
+    const schedules = [
+      createSchedule('2026-04-26T22:00:00+09:00', '2026-04-27T02:00:00+09:00'),
+    ];
+    const tasks: Task[] = [];
+    const result = buildDailyTimeline(date, schedules, tasks);
+
+    // idを除外
+    // Gapのidはcrypto.randomUUID()で生成していて、毎回異なる値になるため。
+    const gapItems = result
+      .filter((item) => item.type === 'gap')
+      .map(({ id: _id, ...rest }) => rest);
+    expect(gapItems).toEqual([
+      {
+        type: 'gap',
+        start_time: `2026-04-26T00:00:00+09:00`,
+        end_time: `2026-04-26T22:00:00+09:00`,
+        isFullDay: false,
+      },
+    ]);
+  });
+
+  it('共通: 0件の場合、1日中空き時間となること', () => {
+    const date = '2026-04-26';
+    const schedules: Schedule[] = [];
+    const tasks: Task[] = [];
+    const result = buildDailyTimeline(date, schedules, tasks);
+
+    // idを除外
+    // Gapのidはcrypto.randomUUID()で生成していて、毎回異なる値になるため。
+    const gapItem = result.map(({ id: _id, ...rest }) => rest);
+
+    expect(gapItem).toEqual([
+      {
+        type: 'gap',
+        start_time: `2026-04-26T00:00:00+09:00`,
+        end_time: `2026-04-27T00:00:00+09:00`,
+        isFullDay: true,
+      },
+    ]);
+  });
+
+  it('共通: 1件の場合、開始と終了の空き時間が発生すること', () => {
+    const date = '2026-04-26';
+    const schedules: Schedule[] = [
+      createSchedule('2026-04-26T10:00:00+09:00', '2026-04-26T11:00:00+09:00'),
+    ];
+    const tasks: Task[] = [];
+    const result = buildDailyTimeline(date, schedules, tasks);
+
+    // idを除外
+    // Gapのidはcrypto.randomUUID()で生成していて、毎回異なる値になるため。
+    const gapItems = result
+      .filter((item) => item.type === 'gap')
+      .map(({ id: _id, ...rest }) => rest);
+    expect(gapItems).toEqual([
+      {
+        type: 'gap',
+        start_time: `2026-04-26T00:00:00+09:00`,
+        end_time: `2026-04-26T10:00:00+09:00`,
+        isFullDay: false,
+      },
+      {
+        type: 'gap',
+        start_time: `2026-04-26T11:00:00+09:00`,
+        end_time: `2026-04-27T00:00:00+09:00`,
+        isFullDay: false,
+      },
+    ]);
+  });
+});
+
+function createSchedule(
+  startTime: string,
+  endTime: string,
+  id: string = String(++idCounter),
+): Schedule {
+  return {
+    id,
+    user_id: 'user1',
+    title: 'テスト予定',
+    memo: null,
+    start_time: startTime,
+    end_time: endTime,
+    created_at: '2026-04-25T00:00:00+09:00',
+    updated_at: null,
+    deleted_at: null,
+  };
+}
+
+function createTask(
+  startTime: string,
+  endTime: string,
+  id: string = String(++idCounter),
+): Task {
+  return {
+    id,
+    user_id: 'user1',
+    title: 'テスト予定',
+    memo: null,
+    start_time: startTime,
+    end_time: endTime,
+    estimated_minutes: 60,
+    status: 'SCHEDULED',
+    created_at: '2026-04-25T00:00:00+09:00',
+    updated_at: null,
+    deleted_at: null,
+  };
+}

--- a/src/utils/timeline.ts
+++ b/src/utils/timeline.ts
@@ -1,0 +1,148 @@
+import { addDays } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
+
+import { Task } from '@/types/task';
+import { Schedule } from '@/types/schedule';
+import { TimelineItem } from '@/types/timeline';
+
+export function buildDailyTimeline(
+  date: string,
+  schedules: Schedule[],
+  tasks: Task[],
+): TimelineItem[] {
+  const merged = mergeToTimeline(schedules, tasks);
+
+  const sorted = sortByStartTime(merged);
+
+  const timeline = insertGaps(sorted, date);
+
+  return timeline;
+}
+
+function mergeToTimeline(schedules: Schedule[], tasks: Task[]): TimelineItem[] {
+  const scheduleItems = schedules.map((schedule) => ({
+    type: 'schedule' as const,
+    id: schedule.id,
+    title: schedule.title,
+    start_time: schedule.start_time,
+    end_time: schedule.end_time,
+    schedule,
+  }));
+
+  // SCHEDULEDのタスクは必ずstart_time, end_timeを持つため非nullアサーションを使用する。
+  const taskItems = tasks.map((task) => ({
+    type: 'task' as const,
+    id: task.id,
+    title: task.title,
+    start_time: task.start_time!,
+    end_time: task.end_time!,
+    task,
+  }));
+
+  const merged = [...scheduleItems, ...taskItems];
+
+  return merged;
+}
+
+// ソートキー
+// 1. start_time 2. end_time 3. type（schedule優先）4. id
+function sortByStartTime(merged: TimelineItem[]): TimelineItem[] {
+  const sorted = merged.sort((a, b) => {
+    const startDiff = a.start_time.localeCompare(b.start_time);
+    if (startDiff !== 0) {
+      return startDiff;
+    }
+
+    const endDiff = a.end_time.localeCompare(b.end_time);
+    if (endDiff !== 0) {
+      return endDiff;
+    }
+
+    const typeOrder = { schedule: 0, task: 1 };
+    const typeDiff =
+      typeOrder[a.type as 'schedule' | 'task'] -
+      typeOrder[b.type as 'schedule' | 'task'];
+    if (typeDiff !== 0) {
+      return typeDiff;
+    }
+
+    return a.id.localeCompare(b.id);
+  });
+
+  return sorted;
+}
+
+function insertGaps(sorted: TimelineItem[], date: string): TimelineItem[] {
+  const startOfDay = new Date(`${date}T00:00:00+09:00`);
+  const endOfDay = addDays(startOfDay, 1);
+  const nextDate = formatInTimeZone(endOfDay, 'Asia/Tokyo', 'yyyy-MM-dd');
+
+  // 0件の場合も1日分の空き時間として返す
+  // 空き時間をタップしてスケジュールをGapの時間範囲で登録できるようにするため、
+  if (sorted.length === 0) {
+    return [
+      {
+        type: 'gap' as const,
+        id: crypto.randomUUID(),
+        start_time: `${date}T00:00:00+09:00`,
+        end_time: `${nextDate}T00:00:00+09:00`,
+        isFullDay: true,
+      },
+    ];
+  }
+
+  const timeline: TimelineItem[] = [];
+  sorted.forEach((current, index) => {
+    if (index > 0) {
+      const prev = timeline[timeline.length - 1];
+      const prevEndTime = new Date(prev.end_time);
+      const currentStartTime = new Date(current.start_time);
+      const diffMinutesInner = Math.floor(
+        (currentStartTime.getTime() - prevEndTime.getTime()) / (1000 * 60),
+      );
+      if (diffMinutesInner > 0) {
+        const gapItem = {
+          type: 'gap' as const,
+          id: crypto.randomUUID(),
+          start_time: prev.end_time,
+          end_time: current.start_time,
+          isFullDay: false,
+        };
+        timeline.push(gapItem);
+      }
+    }
+    timeline.push(current);
+  });
+
+  const firstStartTime = new Date(timeline[0].start_time);
+  const diffMinutesStart = Math.floor(
+    (firstStartTime.getTime() - startOfDay.getTime()) / (1000 * 60),
+  );
+  if (diffMinutesStart > 0) {
+    const gapItem = {
+      type: 'gap' as const,
+      id: crypto.randomUUID(),
+      start_time: `${date}T00:00:00+09:00`,
+      end_time: timeline[0].start_time,
+      isFullDay: false,
+    };
+    timeline.unshift(gapItem);
+  }
+
+  const lastEndTime = new Date(timeline[timeline.length - 1].end_time);
+  const diffMinutesEnd = Math.floor(
+    (endOfDay.getTime() - lastEndTime.getTime()) / (1000 * 60),
+  );
+  if (diffMinutesEnd > 0) {
+    const gapItem = {
+      type: 'gap' as const,
+      id: crypto.randomUUID(),
+      start_time: timeline[timeline.length - 1].end_time,
+      end_time: `${nextDate}T00:00:00+09:00`,
+      isFullDay: false,
+    };
+    timeline.push(gapItem);
+  }
+
+  return timeline;
+}


### PR DESCRIPTION
## 概要
タイムラインの表示ロジックを実装して、時系列表示されるようにしました。

## 変更内容
- buildDailyTimeline関数を実装（マージ・ソート・空き時間挿入）
- buildDailyTimeline関数のテストコードを実装（13ケース）
- タイムラインの表示を修正（時系列表示・時間表示・終日空き対応）
- ESLintのルールを追加（未使用変数）
- date-fns-tzをインストール

## 関連Issue
Close #50