### PR TITLE
fix: improve landing page mobile layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,26 +10,26 @@ function Top() {
             href="/login"
             className="px-4 py-2 border border-black text-sm rounded-full hover:bg-gray-50"
           >
-            ログインはこちら
+            ログイン
           </Link>
           <Link
             href="/signup"
             className="px-4 py-2 bg-black text-white text-sm rounded-full hover:bg-zinc-700"
           >
-            新規登録はこちら
+            新規登録
           </Link>
         </div>
       </header>
 
       <main className="flex-1 flex flex-col items-center justify-center gap-8 px-6 text-center">
         <div className="flex flex-col items-center gap-4 max-w-md">
-          <h1 className="text-2xl font-bold tracking-tight whitespace-nowrap">
+          <h1 className="text-lg font-bold tracking-tight">
             予定とタスクを、1つのタイムラインで。
           </h1>
-          <p className="text-gray-500 text-base">
+          <p className="text-gray-500 text-sm">
             スケジュールとタスクを1画面で管理。
             <br />
-            いつやるか決まっていないタスクも気軽に登録できます。
+            いつやるか決まってなくても登録できます。
           </p>
         </div>
       </main>


### PR DESCRIPTION
## 概要
ランディングページのフォーマット崩れ(スマホ表示)を修正しました。

## 変更内容
- ヘッダーのボタンテキストを短くしました（「ログインはこちら」→「ログイン」など）。
- キャッチコピーのフォントサイズを調整しました。
- 説明文の文言を調整しました。

## 関連Issue
Close #66