### PR TITLE
fix: default date showing previous day due to timezone

### DIFF
--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -1,4 +1,6 @@
 import { createClient } from '@/lib/supabase/server';
+import { format } from 'date-fns';
+import { toZonedTime } from 'date-fns-tz';
 import { getInboxTasks, getDailyTasks } from '@/repositories/tasks';
 import { getDailySchedules } from '@/repositories/schedules';
 import { buildDailyTimeline } from '@/utils/timeline';
@@ -17,7 +19,8 @@ async function Dashboard({ searchParams }: DashboardProps) {
   const { date } = await searchParams;
 
   // dateパラメータが未指定の場合は今日日付をデフォルトにする。
-  const targetDate = date ?? new Date().toISOString().split('T')[0];
+  const today = format(toZonedTime(new Date(), 'Asia/Tokyo'), 'yyyy-MM-dd');
+  const targetDate = date ?? today;
 
   const { data: inboxTasks, error: inboxTasksError } =
     await getInboxTasks(supabase);


### PR DESCRIPTION
## 概要
初期表示の日付が時間帯によって、前日日付になる問題を修正しました。
原因はUTCで日付を生成していたからです。

## 変更内容
- UTCをJSTに変換する処理を追加しました。

## 関連Issue
Close #68 